### PR TITLE
#115 Project-Heimdall/home#55 

### DIFF
--- a/src/modules/project/all-projects/list-all-projects.js
+++ b/src/modules/project/all-projects/list-all-projects.js
@@ -20,6 +20,20 @@ getViewStrategy() {
     this.projects = [];
     this.selectedOrganizations = [];
     this.selectedLanguages = [];
+
+    this.sortDirection = "descending";
+
+    this.selectedSort = 'stars';
+    this.sortOptions = [
+      {value: 'rank', name: 'Rank'},
+      {value: 'default', name: 'Relevance'},
+      {value: 'stars', name: 'Stars'},
+      {value: 'watchers', name: 'Watchers'},
+      {value: 'releases', name: 'Releases'},
+      {value: 'commits', name: 'Commits'},
+      {value: 'contributors', name: 'Contributors'}
+    ];
+
   };
 
   gotoProject(project){
@@ -37,7 +51,6 @@ getViewStrategy() {
         this.projects = JSON.parse(JSON.stringify(projects));
         this.selectedOrganizations = this.getUniqueValues(this.projects, 'organization');
         this.selectedLanguages = this.getUniqueValues(this.projects, 'language');
-        console.log(this.projects);
         return this.projects;
      });
   }

--- a/src/modules/project/common/list.html
+++ b/src/modules/project/common/list.html
@@ -73,27 +73,23 @@
             <form class="form-inline">
               <div class="btn-group">
                 <label class="${sortDirection == 'descending' ? 'btn btn-default active' : 'btn btn-default'}">
-                  <input type="radio" name="sortDirection" checked.bind="$parent.sortDirection" autocomplete="off" value="descending"><i class="fa fa-chevron-down" aria-hidden="true"></i>
+                  <input type="radio" name="sortDirection" checked.two-way="sortDirection" autocomplete="off" value="descending"><i class="fa fa-chevron-down" aria-hidden="true"></i>
                 </label>
                 <label class="${sortDirection == 'ascending' ? 'btn btn-default active' : 'btn btn-default'}">
-                  <input type="radio" name="sortDirection" checked.bind="$parent.sortDirection" autocomplete="off" value="ascending"><i class="fa fa-chevron-up" aria-hidden="true"></i>
+                  <input type="radio" name="sortDirection" checked.two-way="sortDirection" autocomplete="off" value="ascending"><i class="fa fa-chevron-up" aria-hidden="true"></i>
                 </label>
               </div>
               <div class="form-group">
                 <label for="sortProperty" class="sr-only">Sort</label>
-                <select id="sortProperty" ref="sortProperty" class="form-control">
-                  <option value="stars">Stars</option>
-                  <option value="watchers">Watchers</option>
-                  <option value="releases">Releases</option>
-                  <option value="commits">Commits</option>
-                  <option value="contributors">Contributors</option>
+                <select id="sortProperty" value.bind="selectedSort" class="form-control">
+                  <option repeat.for="option of sortOptions" value="${option.value}">${option.name}</option>
                 </select>
               </div>
             </form>
           </div>
 
           <div class="col-lg-12 col-md-12 col-cards">
-            <div repeat.for="repo of projects | sort: { propertyName: sortProperty.value, direction: sortDirection} | filter: { propertyName: 'organization', filterArray: selectedOrganizations}:selectedOrganizations.length | filter: { propertyName: 'language', filterArray: selectedLanguages}:selectedLanguages.length | pick:20" class="clearfix col-lg-6">
+            <div repeat.for="repo of projects | sort: { propertyName: selectedSort, direction: sortDirection} | filter: { propertyName: 'organization', filterArray: selectedOrganizations}:selectedOrganizations.length | filter: { propertyName: 'language', filterArray: selectedLanguages}:selectedLanguages.length | pick:20" class="clearfix col-lg-6">
               <div class="card">
                 <div class="card-header">
                   <h3 class="repo-name"><a route-href="route:project-details-popular; params.bind: {id:repo.id}">${repo.project_name}</a></h3>

--- a/src/modules/project/popular/list.js
+++ b/src/modules/project/popular/list.js
@@ -16,6 +16,18 @@ export class List {
 
     this.selectedOrganizations = [];
     this.selectedLanguages = [];
+
+    this.sortDirection = "descending";
+
+    this.selectedSort = 'rank';
+    this.sortOptions = [
+      {value: 'rank', name: 'Rank'},
+      {value: 'stars', name: 'Stars'},
+      {value: 'watchers', name: 'Watchers'},
+      {value: 'releases', name: 'Releases'},
+      {value: 'commits', name: 'Commits'},
+      {value: 'contributors', name: 'Contributors'}
+    ];
   };
 
   getViewStrategy() {

--- a/src/modules/project/results/result.js
+++ b/src/modules/project/results/result.js
@@ -15,6 +15,19 @@ export class Result {
     this.selectedOrganizations = [];
     this.selectedLanguages = [];
 
+    this.sortDirection = "descending";
+
+    this.selectedSort = 'default';
+    this.sortOptions = [
+      {value: 'rank', name: 'Rank'},
+      {value: 'default', name: 'Relevance'},
+      {value: 'stars', name: 'Stars'},
+      {value: 'watchers', name: 'Watchers'},
+      {value: 'releases', name: 'Releases'},
+      {value: 'commits', name: 'Commits'},
+      {value: 'contributors', name: 'Contributors'}
+    ];
+
 	}
 
   getViewStrategy() {

--- a/src/modules/project/utility/sort.js
+++ b/src/modules/project/utility/sort.js
@@ -1,10 +1,19 @@
 export class SortValueConverter {
   toView(array, config) {
-    var factor = (config.direction || 'ascending') === 'ascending' ? 1 : -1;
-    return array
-      .slice(0)
-      .sort((a, b) => {
-        return (a[config.propertyName] - b[config.propertyName]) * factor
-      });
+    if (config.propertyName == 'default') {
+      if(config.direction === 'ascending'){
+        return array
+          .slice(0)
+          .reverse();
+      }
+      return array;
+    } else {
+      var factor = config.direction === 'ascending' ? 1 : -1;
+      return array
+        .slice(0)
+        .sort((a, b) => {
+          return (a[config.propertyName] - b[config.propertyName]) * factor
+        });
+    }
   }
 }


### PR DESCRIPTION
Added sorting for es rank (relevance) and our internal rank, set default rank for each view.

To test, popular should show "rank" in the drop down. Explore should show "stars" and searching should always default to "relevance."

If you type "cognition" in search, the cognition project should now show up first instead of third like before. In general we should see more relevant searches showing up first.