### PR TITLE
Search bug fixes

### DIFF
--- a/src/modules/project/search/search-bar.js
+++ b/src/modules/project/search/search-bar.js
@@ -16,11 +16,14 @@ export class SearchBar {
 
   executeSearch(searchText) {
     this.router.navigateToRoute('result', { searchText });
+    $('#searchBox .typeahead').typeahead('val', '');
   }
 
   activate() {
-    if (this.router.currentInstruction.fragment) {
+    if (this.router.currentInstruction) {
       this.landing = this.router.currentInstruction.fragment === '/';
+    } else {
+      this.landing = false;
     }
   }
 


### PR DESCRIPTION
Navigating directly to search results (or refreshing) would hang. Seemed to be something with the router not being fully initiated during the check to see if it was the landing page (used for formatting the header), made statement to check if null and set appropriately. May be a more elegant solution to this down the line but this is working for now.

Also made it so search autocomplete hints are cleared when you execute a search. Before they would just hang there and look ugly.