### PR TITLE
"Show all" filter toggle + small popular page fix

### DIFF
--- a/src/modules/project/all-projects/list-all-projects.js
+++ b/src/modules/project/all-projects/list-all-projects.js
@@ -52,6 +52,24 @@ export class ListAllProjects {
       });
   }
 
+  toggleOrg(source) {
+    if (document.getElementsByName('toggleOrg')[0].checked) {
+      this.selectedOrganizations = this.getUniqueValues(this.projects, 'organization');
+      return true;
+    }
+    this.selectedOrganizations = [];
+    return true;
+  }
+
+  toggleLang() {
+    if (document.getElementsByName('toggleLang')[0].checked) {
+      this.selectedLanguages = this.getUniqueValues(this.projects, 'language');
+      return true;
+    }
+    this.selectedLanguages = [];
+    return true;
+  }
+
   // Creates an array of unique values for one property in an array
   getUniqueValues(array, property) {
     const propertyArray = [];

--- a/src/modules/project/common/list.html
+++ b/src/modules/project/common/list.html
@@ -21,11 +21,20 @@
                     <div id="collapseOne" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne">
                         <div class="panel-body">
                             <ul class="list-group">
+                              <li class="list-group-item">
+                                <form>
+                                  <div class="checkbox">
+                                    <label>
+                                      <input type="checkbox" name="toggleOrg" click.delegate="toggleOrg()" checked/> Show All<br/>
+                                    </label>
+                                  </div>
+                                </form>
+                              </li>
                                 <li class="list-group-item" repeat.for="organization of projects | unique: { propertyName: 'organization'}">
                                     <form>
                                         <div class="checkbox">
                                             <label>
-                                                <input type="checkbox" checked.bind="selectedOrganizations" value.bind="organization"> ${organization}
+                                                <input type="checkbox" name="orgCheck" checked.bind="selectedOrganizations" value.bind="organization"> ${organization}
                                             </label>
                                         </div>
                                     </form>
@@ -43,6 +52,15 @@
                     <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
                         <div class="panel-body">
                             <ul class="list-group">
+                              <li class="list-group-item">
+                                <form>
+                                  <div class="checkbox">
+                                    <label>
+                                      <input type="checkbox" name="toggleLang" click.delegate="toggleLang()" checked/> Show All<br/>
+                                    </label>
+                                  </div>
+                                </form>
+                              </li>
                                 <li class="list-group-item" repeat.for="language of projects | unique: { propertyName: 'language'}">
                                     <form>
                                         <div class="checkbox">
@@ -62,7 +80,8 @@
                 <div class="row flex-row">
                     <div class="col-lg-12 col-md-12 col-sm-12">
                         <div class="cards-sorting">
-                            <p>We've found ${projects.length} repositories!</p>
+                            <p if.bind="!landing">We've found ${projects.length} repositories!</p>
+                            <p if.bind="landing"></p>
                             <form class="form-inline">
                                 <div class="btn-group">
                                     <label class="${sortDirection == 'descending' ? 'btn btn-default active' : 'btn btn-default'}">

--- a/src/modules/project/favorites/list-favorites.js
+++ b/src/modules/project/favorites/list-favorites.js
@@ -57,6 +57,24 @@ export class List {
     });
   }
 
+  toggleOrg(source) {
+    if (document.getElementsByName('toggleOrg')[0].checked) {
+      this.selectedOrganizations = this.getUniqueValues(this.projects, 'organization');
+      return true;
+    }
+    this.selectedOrganizations = [];
+    return true;
+  }
+
+  toggleLang() {
+    if (document.getElementsByName('toggleLang')[0].checked) {
+      this.selectedLanguages = this.getUniqueValues(this.projects, 'language');
+      return true;
+    }
+    this.selectedLanguages = [];
+    return true;
+  }
+
   // Creates an array of unique values for one property in an array
   getUniqueValues(array, property) {
     const propertyArray = [];

--- a/src/modules/project/popular/list.js
+++ b/src/modules/project/popular/list.js
@@ -56,6 +56,24 @@ export class List {
     });
   }
 
+  toggleOrg(source) {
+    if (document.getElementsByName('toggleOrg')[0].checked) {
+      this.selectedOrganizations = this.getUniqueValues(this.projects, 'organization');
+      return true;
+    }
+    this.selectedOrganizations = [];
+    return true;
+  }
+
+  toggleLang() {
+    if (document.getElementsByName('toggleLang')[0].checked) {
+      this.selectedLanguages = this.getUniqueValues(this.projects, 'language');
+      return true;
+    }
+    this.selectedLanguages = [];
+    return true;
+  }
+
   // Creates an array of unique values for one property in an array
   getUniqueValues(array, property) {
     const propertyArray = [];

--- a/src/modules/project/results/result.js
+++ b/src/modules/project/results/result.js
@@ -35,6 +35,24 @@ export class Result {
     return activationStrategy.replace;
   }
 
+  toggleOrg(source) {
+    if (document.getElementsByName('toggleOrg')[0].checked) {
+      this.selectedOrganizations = this.getUniqueValues(this.projects, 'organization');
+      return true;
+    }
+    this.selectedOrganizations = [];
+    return true;
+  }
+
+  toggleLang() {
+    if (document.getElementsByName('toggleLang')[0].checked) {
+      this.selectedLanguages = this.getUniqueValues(this.projects, 'language');
+      return true;
+    }
+    this.selectedLanguages = [];
+    return true;
+  }
+
   // Creates an array of unique values for one property in an array
   getUniqueValues(array, property) {
     const propertyArray = [];


### PR DESCRIPTION
Quick and dirty toggle feature to show all and show none for filters. Not perfect but should be facilitate testing until we rework filters. For all pages with filters you should be able to click the "show all" checkbox for languages and organization filters. Depending on the current state of the show all checkbox, it will select or deselect all filters for that property.

Popular page used to show "20 results found" that has been removed.

 