### PR TITLE
Functional new filters for results page

### DIFF
--- a/src/search/results.html
+++ b/src/search/results.html
@@ -28,6 +28,9 @@
 
           <div class="collapse" id="collapseExample">
             FILTERS
+
+            <select id="filterOrg" multiple="multiple"></select>
+
           </div>
         </div>
       </div>

--- a/src/search/results.html
+++ b/src/search/results.html
@@ -12,7 +12,7 @@
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div class="filter-wrapper clearfix">
             <ul class='list-inline pull-left'>
-              <li>2,554 results for:</li>
+              <li>${projects.length} results for: ${searchText}</li>
               <li>
                 <span class="stage-chip">Item 1 <small>(200)</small> <a href="#"><i class="material-icons">close</i></a></span>
                 </li>
@@ -27,10 +27,8 @@
           </div>
 
           <div class="collapse" id="collapseExample">
-            FILTERS
-
             <select id="filterOrg" multiple="multiple"></select>
-
+            <select id="filterLang" multiple="multiple"></select>
           </div>
         </div>
       </div>

--- a/src/search/results.js
+++ b/src/search/results.js
@@ -1,6 +1,8 @@
 import { inject, bindable } from 'aurelia-framework';
 import { activationStrategy } from 'aurelia-router';
 import { EventAggregator } from 'aurelia-event-aggregator';
+import $ from 'bootstrap';
+import { multiselect } from 'bootstrap-multiselect';
 import { DataContext } from '../services/datacontext';
 import { Filters } from '../components/filters';
 
@@ -42,6 +44,7 @@ export class Results {
           this.projects = projects;
           this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
           this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
+          this.rebuild(projects);
           return this.projects;
         });
     }
@@ -53,12 +56,56 @@ export class Results {
         this.projects = projects;
         this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
         this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
+        this.rebuild(projects);
         return this.projects;
       });
   }
 
+  rebuild(projects) {
+    const options = [];
+    const unique = this.getUniqueValues(projects, 'organization');
+    for (const org of unique) {
+      options.push({ label: org, title: org, value: org, selected: false });
+    }
+    $('#filterOrg').multiselect('dataprovider', options);
+  }
+
+  attached() {
+    $('#filterOrg').multiselect({
+      includeSelectAllOption: true,
+      enableFiltering: true,
+      disableIfEmpty: true,
+      enableCaseInsensitiveFiltering: true,
+      buttonText(options, select) {
+        return `Organizations (${options.length})`;
+      },
+    });
+
+    $('#filterOrg').on('change', ev => {
+      if ($('#filterOrg').val()) {
+        this.filters.selectedOrganizations = $('#filterOrg').val();
+      } else {
+        this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
+      }
+    });
+
+    this.rebuild(this.projects);
+  }
+
   detached() {
     this.ea.publish('detachResults');
+  }
+
+  getUniqueValues(array, property) {
+    const propertyArray = [];
+    for (const object of array) {
+      if (object[property]) {
+        propertyArray.push(object[property]);
+      } else {
+        propertyArray.push('None');
+      }
+    }
+    return Array.from(new Set(propertyArray));
   }
 
 }

--- a/src/search/search-bar.js
+++ b/src/search/search-bar.js
@@ -67,11 +67,11 @@ export class SearchBar {
         source: suggestions,
       });
 
-    $('#searchBox .typeahead').bind('typeahead:select', (ev, suggestion) => {
+    $('#searchBox .typeahead').on('typeahead:select', (ev, suggestion) => {
       this.executeSearch(suggestion);
     });
 
-    $('#searchBox .typeahead').bind('typeahead:autocompleted', (ev, suggestion) => {
+    $('#searchBox .typeahead').on('typeahead:autocompleted', (ev, suggestion) => {
       this.searchText = suggestion;
     });
   }

--- a/src/services/datacontext.js
+++ b/src/services/datacontext.js
@@ -55,12 +55,4 @@ export class DataContext {
       .then(response => response.json());
   }
 
-  findComponentDependencies(org, name) {
-    const adjustedURL = `${baseUrl}/findComponentDependencies/${org}/${name}`;
-    return this.http.fetch(adjustedURL, {
-      method: 'GET',
-    })
-      .then(response => response.json());
-  }
-
 }


### PR DESCRIPTION
Functional bootstrap multiselect components added to the results page (explore will be added once results is finalized). Style and final functionality not finalized, but filters should work. Pills still in progress.

- On results page (after searching), hitting "FILTERS" arrow button should reveal org and lang filters
- Clicking a filter should produce a drop down with all the orgs or langs (none selected is now default and none selected shows all results like discussed)
- Select All toggles all items
- Checking filter items should work as expected (e.g. only checked filter items are displayed)
- Search bar within drop down should allow case insensitive filtering of filter items
- Filter dropdown text changes with none selected, n selected, and all selected (this is mainly to demonstrate functionality)
- New search should destroy and rebuild new filters for new results