### PR TITLE
use internal ip for communication

### DIFF
--- a/ops/nginx.conf
+++ b/ops/nginx.conf
@@ -44,7 +44,7 @@ http {
     include /etc/nginx/default.d/*.conf;
 
     location /api/ {
-      proxy_pass http://52.90.121.233:3001/api/;
+      proxy_pass http://172.31.25.31:3001/api/;
     }
 
     # redirect server error pages to the static page /40x.html


### PR DESCRIPTION
using security group referencing which allows for internal ip usage for inter-instance communication