### PR TITLE
Loading animations, FireFox compatibility, build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,19 @@ env:
   - secure: TXnv6nOdslOopR2rDC0SCMOyOSFxBvtGZBR2tZvpjxiBDGQ+G4SVwIAT/Mrenha5xfIZ1TAaRyy36mMzuw40c/SR0aXbAP3ehLgnn4Ik/IGMUasklLhnRMMn2VA1Set3dctEaNqyJ/JNvsivZfFTMLpCH/VfyXmiCaAaaVVyH3BYxXBaScD4SQKLUazPf5JumXI0PTzJmVcFryz0gJGUvSIE0LR/OlaouDxZKASq5174FurW+ChjGrEZki85goMvUsvF1djRqzKJkS+Vp/Rg5xJtA/Wjw6ENPsRJ7zTNCeY/PZmXe08YQsoCzzc3JhYrcwLgHfL/jAqa9uC5NIeUKc0MDQ6MwdW594W7gLGOlHNBMQ+bkHc+laP0DC2vHNFmBlxXw5Bd9B143hzQFYas73+8+MMGFB4OkevF0j6zCz5XWVnNrNyxob6AItk5PsT3h6QYCfzK7vt6FZLzlqjFHeQ1bXuBJ18y86HhmiBYGuHH2jL3xqw4Qow1qj4MXEl+rNvQh865qs0F23M1sXmfTeby6SofyJq1XC4GtZtsHSbVxronBCwlm2Zixiros69OqU1L5I9wckNzVCjiTyIO46Baj96T4mrWlbMq4YAH5YPRuEAhreghcDgbQi3fEIZw3WlVHmJtCfsrAu4PQHM1qnYqaUf8bjWT7VOJtuZ8Y68=
   - HEIMDALL_VERSION_NUMBER=1.0.0
   - HEIMDALL_BUILD_LABEL=$HEIMDALL_VERSION_NUMBER.$TRAVIS_BUILD_NUMBER-pre-alpha-$TRAVIS_BRANCH
+  - HEIMDALL_BRANCH=$TRAVIS_BRANCH
   - HEIMDALL_PACKAGE_NAME=heimdall-ui-dev-$HEIMDALL_BUILD_LABEL.zip
 install:
 - npm install -g gulp
 - npm install -g jspm
 - npm install -g coveralls
-- npm install --production
+- npm install
 - jspm config registries.github.auth $JSPM_GITHUB_AUTH_TOKEN
 - jspm install -y
 script:
 - sed -i "s@{BUILD_LABEL}@$HEIMDALL_BUILD_LABEL@" stageConf.js
-- gulp build
+- sed -i "s@{BRANCH}@$HEIMDALL_BRANCH@" src/main.js
+- gulp bundle
 - npm prune --production
 before_deploy:
 - zip -rq $HEIMDALL_PACKAGE_NAME *

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - npm install -g gulp
 - npm install -g jspm
 - npm install -g coveralls
-- npm install
+- npm install --production
 - jspm config registries.github.auth $JSPM_GITHUB_AUTH_TOKEN
 - jspm install -y
 script:

--- a/config.js
+++ b/config.js
@@ -13,7 +13,6 @@ System.config({
     "npm:*": "jspm_packages/npm/*"
   },
   baseUrl: "/",
-
   meta: {
     "bootstrap": {
       "deps": [
@@ -21,7 +20,6 @@ System.config({
       ]
     }
   },
-
   map: {
     "aurelia-animator-css": "npm:aurelia-animator-css@1.0.1",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0",

--- a/config.js
+++ b/config.js
@@ -51,7 +51,7 @@ System.config({
     "font-awesome": "npm:font-awesome@4.6.3",
     "jquery": "npm:jquery@2.2.4",
     "jquery-ui": "github:components/jqueryui@1.12.1",
-    "material-design-icons": "github:google/material-design-icons@3.0.1",
+    "material-design-icons-iconfont": "npm:material-design-icons-iconfont@3.0.1",
     "moment": "npm:moment@2.15.1",
     "numeral": "npm:numeral@1.5.3",
     "octicons": "npm:octicons@4.4.0",
@@ -243,7 +243,7 @@ System.config({
       "base64-js": "npm:base64-js@0.0.8",
       "child_process": "github:jspm/nodelibs-child_process@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "ieee754": "npm:ieee754@1.1.6",
+      "ieee754": "npm:ieee754@1.1.8",
       "isarray": "npm:isarray@1.0.0",
       "process": "github:jspm/nodelibs-process@0.1.2"
     },
@@ -263,6 +263,12 @@ System.config({
     },
     "npm:inherits@2.0.1": {
       "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:material-design-icons-iconfont@3.0.1": {
+      "fs": "github:jspm/nodelibs-fs@0.1.2",
+      "path": "github:jspm/nodelibs-path@0.1.0",
+      "process": "github:jspm/nodelibs-process@0.1.2",
+      "readline": "github:jspm/nodelibs-readline@0.1.0"
     },
     "npm:numeral@1.5.3": {
       "fs": "github:jspm/nodelibs-fs@0.1.2"

--- a/config.js
+++ b/config.js
@@ -13,6 +13,7 @@ System.config({
     "npm:*": "jspm_packages/npm/*"
   },
   baseUrl: "/",
+
   meta: {
     "bootstrap": {
       "deps": [
@@ -20,6 +21,7 @@ System.config({
       ]
     }
   },
+
   map: {
     "aurelia-animator-css": "npm:aurelia-animator-css@1.0.1",
     "aurelia-bootstrapper": "npm:aurelia-bootstrapper@1.0.0",
@@ -49,9 +51,11 @@ System.config({
     "font-awesome": "npm:font-awesome@4.6.3",
     "jquery": "npm:jquery@2.2.4",
     "jquery-ui": "github:components/jqueryui@1.12.1",
+    "material-design-icons": "github:google/material-design-icons@3.0.1",
     "moment": "npm:moment@2.15.1",
     "numeral": "npm:numeral@1.5.3",
     "octicons": "npm:octicons@4.4.0",
+    "roboto-fontface": "npm:roboto-fontface@0.6.0",
     "showdown": "github:showdownjs/showdown@1.4.3",
     "text": "github:systemjs/plugin-text@0.0.3",
     "typeahead.js": "npm:typeahead.js@0.11.1",

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <link href="jspm_packages/npm/octicons@4.4.0/build/font/octicons.css" rel="stylesheet">
     <link href="jspm_packages/npm/roboto-fontface@0.6.0/css/roboto/roboto-fontface.css" rel="stylesheet">
     <link href="jspm_packages/npm/roboto-fontface@0.6.0/css/roboto-condensed/roboto-condensed-fontface.css" rel="stylesheet">
-    <link href="jspm_packages/github/google/material-design-icons@3.0.1/iconfont/material-icons.css" rel="stylesheet">
+    <link href="jspm_packages/npm/material-design-icons-iconfont@3.0.1/dist/material-design-icons.css" rel="stylesheet">
 
 </head>
 

--- a/index.html
+++ b/index.html
@@ -12,9 +12,9 @@
     <link href="styles/styles.css" rel="stylesheet">
     <link href="styles/font-awesome.css" rel="stylesheet">
     <link href="jspm_packages/npm/octicons@4.4.0/build/font/octicons.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i,900,900i," rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,300i,400,400i,700,700i" rel="stylesheet">
+    <link href="jspm_packages/npm/roboto-fontface@0.6.0/css/roboto/roboto-fontface.css" rel="stylesheet">
+    <link href="jspm_packages/npm/roboto-fontface@0.6.0/css/roboto-condensed/roboto-condensed-fontface.css" rel="stylesheet">
+    <link href="jspm_packages/github/google/material-design-icons@3.0.1/iconfont/material-icons.css" rel="stylesheet">
 
 </head>
 

--- a/package.json
+++ b/package.json
@@ -95,9 +95,11 @@
       "font-awesome": "npm:font-awesome@^4.5.0",
       "jquery": "npm:jquery@^2.2.3",
       "jquery-ui": "github:components/jqueryui@^1.12.0",
+      "material-design-icons": "github:google/material-design-icons@^3.0.1",
       "moment": "npm:moment@^2.15.0",
       "numeral": "npm:numeral@^1.5.3",
       "octicons": "npm:octicons@^4.3.0",
+      "roboto-fontface": "npm:roboto-fontface@^0.6.0",
       "showdown": "github:showdownjs/showdown@^1.4.2",
       "text": "github:systemjs/plugin-text@^0.0.3",
       "typeahead.js": "npm:typeahead.js@^0.11.1"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
       "font-awesome": "npm:font-awesome@^4.5.0",
       "jquery": "npm:jquery@^2.2.3",
       "jquery-ui": "github:components/jqueryui@^1.12.0",
-      "material-design-icons": "github:google/material-design-icons@^3.0.1",
+      "material-design-icons-iconfont": "npm:material-design-icons-iconfont@^3.0.1",
       "moment": "npm:moment@^2.15.0",
       "numeral": "npm:numeral@^1.5.3",
       "octicons": "npm:octicons@^4.3.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "karma-coverage": "^0.5.3",
     "karma-jasmine": "^0.3.5",
     "karma-jspm": "2.0.1-beta.2",
-    "material-design-icons": "^2.2.3",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,8 @@
 import { DialogService } from 'aurelia-dialog';
 import { inject } from 'aurelia-framework';
-import { ReadmeModal } from './components/modals/readme-modal';
-import { ContributorsModal } from './components/modals/contributors-modal.js';
-import { FeedbackModal } from './components/modals/feedback-modal.js';
+import { ReadmeModal } from 'components/modals/readme-modal';
+import { ContributorsModal } from 'components/modals/contributors-modal.js';
+import { FeedbackModal } from 'components/modals/feedback-modal.js';
 import { StageConfig } from '../stageConf';
 
 @inject(DialogService, StageConfig)

--- a/src/components/headers/project-details-header.js
+++ b/src/components/headers/project-details-header.js
@@ -1,6 +1,6 @@
 import { inject } from 'aurelia-framework';
 import { activationStrategy } from 'aurelia-router';
-import { DataContext } from '../../services/datacontext';
+import { DataContext } from 'services/datacontext';
 
 @inject(DataContext)
 export class ProjectDetailsHeader {

--- a/src/explore/explore.html
+++ b/src/explore/explore.html
@@ -46,6 +46,10 @@
         </ul>
       </div>
       <div class="col-lg-12 cards-wrapper">
+
+        <div if.bind="resultCount < 1" class="loader" width="100%" height="100%" align="center" valign="center">
+              <img src="img/loading.svg" width="100px" alt="Loading...">
+        </div>
           <div class="row"
             virtual-repeat.for="repo of projects |
             sort: { propertyName: selectedSort, direction: sortDirection} |

--- a/src/explore/explore.html
+++ b/src/explore/explore.html
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  <div class="container-fluid">
+  <div class="container-fluid loading-wrapper">
     <div class="row">
       <div class="col-lg-12 col-chips">
         <ul class='list-inline'>

--- a/src/explore/explore.js
+++ b/src/explore/explore.js
@@ -51,7 +51,7 @@ export class Explore {
           this.rebuildFilterLang(projects);
           this.rebuildFilterOrigin(projects);
           return this.projects;
-        }, 1000);
+        }, 500);
       });
   }
 

--- a/src/explore/explore.js
+++ b/src/explore/explore.js
@@ -42,14 +42,16 @@ export class Explore {
   getData() {
     return this.dataContext.getAll()
       .then(projects => {
-        this.projects = JSON.parse(JSON.stringify(projects));
-        this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
-        this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
-        this.filters.selectedOrigins = this.filters.getUniqueValues(this.projects, 'origin');
-        this.rebuildFilterOrg(projects);
-        this.rebuildFilterLang(projects);
-        this.rebuildFilterOrigin(projects);
-        return this.projects;
+        setTimeout(() => {
+          this.projects = JSON.parse(JSON.stringify(projects));
+          this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
+          this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
+          this.filters.selectedOrigins = this.filters.getUniqueValues(this.projects, 'origin');
+          this.rebuildFilterOrg(projects);
+          this.rebuildFilterLang(projects);
+          this.rebuildFilterOrigin(projects);
+          return this.projects;
+        }, 1000);
       });
   }
 

--- a/src/explore/explore.js
+++ b/src/explore/explore.js
@@ -2,8 +2,8 @@ import { inject, bindable } from 'aurelia-framework';
 import { Router } from 'aurelia-router';
 import $ from 'bootstrap';
 import { multiselect } from 'bootstrap-multiselect';
-import { DataContext } from '../services/datacontext';
-import { Filters } from '../components/filters';
+import { DataContext } from 'services/datacontext';
+import { Filters } from 'components/filters';
 
 @inject(DataContext, Router, Filters)
 export class Explore {

--- a/src/favorites/favorites.js
+++ b/src/favorites/favorites.js
@@ -2,8 +2,8 @@
 
 import { inject } from 'aurelia-framework';
 import { Router } from 'aurelia-router';
-import { DataContext } from '../services/datacontext';
-import { Filters } from '../components/filters';
+import { DataContext } from 'services/datacontext';
+import { Filters } from 'components/filters';
 
 @inject(DataContext, Router, Filters)
 export class Favorites {

--- a/src/less/stage-card.less
+++ b/src/less/stage-card.less
@@ -88,7 +88,7 @@
   .hover-card {
     transition: all 0.2s linear;
 
-    &:hover { 
+    &:hover {
       transform: translateY(-5px);
 
       .card-header {
@@ -109,9 +109,9 @@
 		box-shadow: 0px 4px 8px rgba(0,0,0,0.1);
 		position: relative;
 		margin-bottom: 20px;
-    
+
     .repo-status {
-      font-family: "Roboto Condensed";
+      font-family: Roboto-Condensed;
       font-weight: 500;
     }
 
@@ -136,7 +136,7 @@
 			padding-top: 10px;
 
       .actions-icons {
-        margin-right: 10px; 
+        margin-right: 10px;
       }
 
 			.pull-right {
@@ -164,7 +164,7 @@
 
 			.ribbon {
 				font-size: @font-size-smaller;
-				font-family: 'Roboto Condensed';
+				font-family: Roboto-Condensed;
 				font-weight: bold;
 				letter-spacing: -0.25px;
 				text-transform: uppercase;
@@ -326,7 +326,7 @@
     &:first-child {
       margin-top: 0;
     }
-		
+
 		.last-updated {
 			border-bottom: none;
 			margin-bottom: 15px;

--- a/src/less/stage-home.less
+++ b/src/less/stage-home.less
@@ -15,7 +15,7 @@
       text-align: center;
       font-weight: bold;
       text-transform: uppercase;
-      font-family: "Roboto Condensed";
+      font-family: Roboto-Condensed;
       letter-spacing: 2px;
 
       .material-icons {

--- a/src/less/stage-scaffolding.less
+++ b/src/less/stage-scaffolding.less
@@ -311,6 +311,12 @@ a {
 	}
 }
 
+.loader {
+  text-align: center;
+  top: 50%;
+  left: 50%;
+}
+
 .lined-header {
   .btn-link {
     padding-top: 3px;
@@ -396,7 +402,7 @@ footer {
     > [class*='col-'] {
       margin-bottom: 5px;
     }
-  }  
+  }
 
   .list-inline {
     text-align: center;

--- a/src/less/stage-scaffolding.less
+++ b/src/less/stage-scaffolding.less
@@ -69,7 +69,7 @@ h3{
   letter-spacing: 1px;
   margin-top: 0;
   text-transform: uppercase;
-  font-family: "Roboto Condensed";
+  font-family: Roboto-Condensed;
   font-weight: bold;
   color: lighten(@black, 50%);
 }
@@ -301,7 +301,7 @@ a {
 		}
 
 		.txt-loading {
-			font-family: 'Roboto Condensed';
+			font-family: Roboto-Condensed;
 			font-style: italic;
 			font-weight: bold;
 			letter-spacing: 3px;
@@ -315,6 +315,15 @@ a {
   text-align: center;
   top: 50%;
   left: 50%;
+}
+
+.loading-wrapper {
+  .loader {
+    img {
+      width: 200px;
+      margin-top: 50px;
+    }
+  }
 }
 
 .lined-header {

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,3 @@
-import 'bootstrap';
-
 export function configure(aurelia) {
   aurelia.use
     .standardConfiguration()

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,10 @@
 export function configure(aurelia) {
   aurelia.use
     .standardConfiguration()
-    .developmentLogging()
     .plugin('aurelia-dialog')
     .plugin('aurelia-ui-virtualization');
+
+  if ('{BRANCH}' != 'master') { aurelia.use.developmentLogging(); } // eslint-disable-line
 
   // Uncomment the line below to enable animation.
   // aurelia.use.plugin('aurelia-animator-css');

--- a/src/popular/popular.html
+++ b/src/popular/popular.html
@@ -9,11 +9,14 @@
     </ul>
   </div>
 
-  <div class="container-fluid">
+  <div class="container-fluid loading-wrapper">
     <div class="row">
       <div class="col-lg-12 cards-wrapper">
           <div class="home-tab tab-content">
             <div role="tabpanel" class="tab-pane active" id="popular">
+              <div if.bind="projects.length < 1" class="loader" width="100%" height="100%" align="center" valign="center">
+                <img src="img/loading.svg" width="100px" alt="Loading...">
+              </div>
               <template repeat.for="repo of projects | sort: { propertyName: selectedSort, direction: sortDirection} | chunk: 3">
                 <div class="row">
                   <compose view-model="../components/card" model.bind="repo[0]"></compose>
@@ -34,7 +37,7 @@
 
     <div class="row">
       <div class="col-lg-12 col-btn">
-        <button class="btn btn-default" click.delegate="router.navigateToRoute('explore')">Explore All Projects<i class="material-icons">keyboard_arrow_right</i></button>
+        <button if.bind="projects.length > 0" class="btn btn-default" click.delegate="router.navigateToRoute('explore')">Explore All Projects<i class="material-icons">keyboard_arrow_right</i></button>
       </div>
     </div>
   </div>

--- a/src/popular/popular.js
+++ b/src/popular/popular.js
@@ -29,8 +29,10 @@ export class Popular {
 
   getData() {
     return this.dataContext.findPopular().then(results => {
-      this.projects = results;
-      return this.projects;
+      setTimeout(() => {
+        this.projects = results;
+        return this.projects;
+      }, 500);
     });
   }
 

--- a/src/popular/popular.js
+++ b/src/popular/popular.js
@@ -1,6 +1,6 @@
 import { inject } from 'aurelia-framework';
 import { Router } from 'aurelia-router';
-import { DataContext } from '../services/datacontext';
+import { DataContext } from 'services/datacontext';
 
 @inject(DataContext, Router)
 export class Popular {

--- a/src/project-details/project-details.html
+++ b/src/project-details/project-details.html
@@ -237,6 +237,7 @@
 
             <h3>Similar Projects</h3>
             <div class="media-list media-list-projects list-group">
+
               <template repeat.for="project of similarProjects | pick:3">
                 <a route-href="route:project-details; params.bind: {id:project.project_id}" target="_blank" class="list-group-item">
                   <span class="media">
@@ -251,6 +252,11 @@
                 </a>
               </template>
             </div>
+
+            <div if.bind="similarProjects.length < 1" class="loader" width="100%" height="100%" align="center" valign="center">
+              <img src="img/loading.svg" width="100px" alt="Loading...">
+            </div>
+
           </div>
         </div>
       </div>

--- a/src/project-details/project-details.html
+++ b/src/project-details/project-details.html
@@ -239,7 +239,7 @@
             <div class="media-list media-list-projects list-group">
 
               <template repeat.for="project of similarProjects | pick:3">
-                <a route-href="route:project-details; params.bind: {id:project.project_id}" target="_blank" class="list-group-item">
+                <a route-href="route:project-details; params.bind: {id:project.project_id}" class="list-group-item">
                   <span class="media">
                     <span class="media-left">
                       <img class="img-circle media-object" src="https://github.com/${project.project_org_name}.png" onError="this.onerror=null;this.src='/img/language-icons/organization-default.svg';">

--- a/src/project-details/project-details.js
+++ b/src/project-details/project-details.js
@@ -33,7 +33,9 @@ export class ProjectDetails {
     this.dataContext.findSimilarProjects(params.id).then(similarProjects => {
       // TODO should be using promises to catch errors
       if (!similarProjects.error) {
-        this.similarProjects = similarProjects;
+        setTimeout(() => {
+          this.similarProjects = similarProjects;
+        }, 1000);
       }
     });
 

--- a/src/project-details/project-details.js
+++ b/src/project-details/project-details.js
@@ -1,6 +1,6 @@
 import { inject, bindable } from 'aurelia-framework';
 import { Router, activationStrategy } from 'aurelia-router';
-import { DataContext } from '../services/datacontext';
+import { DataContext } from 'services/datacontext';
 
 @inject(DataContext, Router)
 export class ProjectDetails {

--- a/src/project-details/project-details.js
+++ b/src/project-details/project-details.js
@@ -35,7 +35,7 @@ export class ProjectDetails {
       if (!similarProjects.error) {
         setTimeout(() => {
           this.similarProjects = similarProjects;
-        }, 1000);
+        }, 500);
       }
     });
 

--- a/src/search/results.html
+++ b/src/search/results.html
@@ -41,9 +41,12 @@
     </div>
   </div>
 
-  <div class="container search-results">
+  <div class="container search-results loading-wrapper">
     <div class="row flex-row">
       <div class="col-lg-12 cards-wrapper">
+        <div if.bind="resultCount < 1" class="loader" width="100%" height="100%" align="center" valign="center">
+          <img src="img/loading.svg" width="100px" alt="Loading...">
+        </div>
         <div class="row"
           virtual-repeat.for="repo of projects |
           sort: { propertyName: selectedSort, direction: sortDirection} |

--- a/src/search/results.js
+++ b/src/search/results.js
@@ -41,19 +41,23 @@ export class Results {
   }
 
   activate(params) {
+    this.projects = [];
+
     if (!(params.searchText) || params.searchText === '') {
       this.searchText = 'Everything';
       return this.dataContext.getAll()
         .then(projects => {
-          this.projects = projects;
-          this.resultCount = this.projects.length;
-          this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
-          this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
-          this.filters.selectedOrigins = this.filters.getUniqueValues(this.projects, 'origin');
-          this.rebuildFilterOrg(projects);
-          this.rebuildFilterLang(projects);
-          this.rebuildFilterOrigin(projects);
-          return this.projects;
+          setTimeout(() => {
+            this.projects = projects;
+            this.resultCount = this.projects.length;
+            this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
+            this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
+            this.filters.selectedOrigins = this.filters.getUniqueValues(this.projects, 'origin');
+            this.rebuildFilterOrg(projects);
+            this.rebuildFilterLang(projects);
+            this.rebuildFilterOrigin(projects);
+            return this.projects;
+          }, 200);
         });
     }
 
@@ -63,15 +67,17 @@ export class Results {
 
     return this.dataContext.search(params.searchText)
       .then(projects => {
-        this.projects = projects;
-        this.resultCount = this.projects.length;
-        this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
-        this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
-        this.filters.selectedOrigins = this.filters.getUniqueValues(this.projects, 'origin');
-        this.rebuildFilterOrg(projects);
-        this.rebuildFilterLang(projects);
-        this.rebuildFilterOrigin(projects);
-        return this.projects;
+        setTimeout(() => {
+          this.projects = projects;
+          this.resultCount = this.projects.length;
+          this.filters.selectedOrganizations = this.filters.getUniqueValues(this.projects, 'organization');
+          this.filters.selectedLanguages = this.filters.getUniqueValues(this.projects, 'language');
+          this.filters.selectedOrigins = this.filters.getUniqueValues(this.projects, 'origin');
+          this.rebuildFilterOrg(projects);
+          this.rebuildFilterLang(projects);
+          this.rebuildFilterOrigin(projects);
+          return this.projects;
+        }, 200);
       });
   }
 

--- a/src/search/results.js
+++ b/src/search/results.js
@@ -3,8 +3,8 @@ import { activationStrategy } from 'aurelia-router';
 import { EventAggregator } from 'aurelia-event-aggregator';
 import $ from 'bootstrap';
 import { multiselect } from 'bootstrap-multiselect';
-import { DataContext } from '../services/datacontext';
-import { Filters } from '../components/filters';
+import { DataContext } from 'services/datacontext';
+import { Filters } from 'components/filters';
 
 @inject(DataContext, Filters, EventAggregator)
 export class Results {

--- a/src/search/search-bar-secondary.js
+++ b/src/search/search-bar-secondary.js
@@ -3,7 +3,7 @@ import { Router } from 'aurelia-router';
 import { EventAggregator } from 'aurelia-event-aggregator';
 import $ from 'jquery';
 import { typeahead } from 'corejs-typeahead';
-import { DataContext } from '../services/datacontext';
+import { DataContext } from 'services/datacontext';
 
 @inject(DataContext, Router, EventAggregator)
 export class SearchBarSecondary {

--- a/src/search/search-bar.js
+++ b/src/search/search-bar.js
@@ -3,7 +3,7 @@ import { Router } from 'aurelia-router';
 import { EventAggregator } from 'aurelia-event-aggregator';
 import $ from 'jquery';
 import { typeahead } from 'corejs-typeahead';
-import { DataContext } from '../services/datacontext';
+import { DataContext } from 'services/datacontext';
 
 @inject(DataContext, Router, EventAggregator)
 export class SearchBar {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -6544,7 +6544,7 @@ h3 {
   letter-spacing: 1px;
   margin-top: 0;
   text-transform: uppercase;
-  font-family: "Roboto Condensed";
+  font-family: Roboto-Condensed;
   font-weight: bold;
   color: #808080;
 }
@@ -6731,7 +6731,7 @@ a:focus {
   margin-bottom: 10px;
 }
 .splash .loading .txt-loading {
-  font-family: 'Roboto Condensed';
+  font-family: Roboto-Condensed;
   font-style: italic;
   font-weight: bold;
   letter-spacing: 3px;
@@ -6742,6 +6742,10 @@ a:focus {
   text-align: center;
   top: 50%;
   left: 50%;
+}
+.loading-wrapper .loader img {
+  width: 200px;
+  margin-top: 50px;
 }
 .lined-header .btn-link {
   padding-top: 3px;
@@ -6841,7 +6845,7 @@ footer .bah-logo {
   text-align: center;
   font-weight: bold;
   text-transform: uppercase;
-  font-family: "Roboto Condensed";
+  font-family: Roboto-Condensed;
   letter-spacing: 2px;
 }
 .home-tabs > li > a .material-icons {
@@ -7453,7 +7457,7 @@ label.btn > input[type='radio'] {
   margin-bottom: 20px;
 }
 .cards-wrapper .card .repo-status {
-  font-family: "Roboto Condensed";
+  font-family: Roboto-Condensed;
   font-weight: 500;
 }
 .cards-wrapper .card .last-updated {
@@ -7494,7 +7498,7 @@ label.btn > input[type='radio'] {
 }
 .cards-wrapper .card .ribbon-wrapper .ribbon {
   font-size: 12px;
-  font-family: 'Roboto Condensed';
+  font-family: Roboto-Condensed;
   font-weight: bold;
   letter-spacing: -0.25px;
   text-transform: uppercase;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -6738,6 +6738,11 @@ a:focus {
   font-size: 21px;
   opacity: 0.4;
 }
+.loader {
+  text-align: center;
+  top: 50%;
+  left: 50%;
+}
 .lined-header .btn-link {
   padding-top: 3px;
   padding-bottom: 3px;


### PR DESCRIPTION
Loading animations now appear for popular projects, explore, search results, and similar projects. The all have slight artificial delays for testing/smoothness that may be removed once more finalized. Loading animations are tied to individual requests, not entire view promises. This allows user to navigate away/use page while waiting for certain componenets to load (e.g. similar projects is usually very slow but you can still see project details while it loads).

FireFox brought up to compatibility. Main issues was cross scripting it seemed. Material icons and fonts moved from CDN to package manager which fixed the issue. 

Material icons was very slow so while fixing that I also made some improvements to the build process, mainly bundling instead of building to minimize requests (went from roughly 100+ requests to under 100 requests for significant improvement). Also disabling Aurelia template debugging on production.