### PR TITLE
Minor style fixes for sticky navbar and the alpha/beta tag to logo.

### DIFF
--- a/about.html
+++ b/about.html
@@ -30,7 +30,7 @@
 		<div id="parallax">
 			<div data-depth="0.6" class="layer">
 				<div class="some-space">
-					<h1>Accelerating Innovation &amp; Delivery Through Code Reuse</h1>
+					<h1>Accelerating Innovation <span class="text-variant">&amp;</span> Delivery <span class="text-variant">through</span> Code Reuse</h1>
 					<p>Intelligent discovery of code, components, and full stacks through a simple search for reusable technical assets that can be assembled to accelerate development efforts</p>
 				</div>
 			</div>

--- a/about.html
+++ b/about.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<meta charset="UTF-8">
-		<title>Stage Landing page</title>
+		<meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="description" content="">
+    <meta name="author" content="">
+    <link rel="icon" type="image/png" href="favicon.png">
+    <title>Stage | About Stage</title>
 		<link rel="stylesheet" href="styles/styles.css">
 		<link rel="stylesheet" href="about/styles/about.css">
 		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">

--- a/about/styles/about.css
+++ b/about/styles/about.css
@@ -13,6 +13,11 @@ body {
   margin-bottom: 40px;
 }
 
+.navbar-default .navbar-brand:after {
+  left: 138px;
+  bottom: 7px;
+}
+
 img {
   max-width: 100%;
 }

--- a/about/styles/about.css
+++ b/about/styles/about.css
@@ -58,7 +58,6 @@ h3{
   margin-top: 0;
   line-height: 0 !important;
   max-width: 100%;
-  // overflow: hidden;
   white-space: nowrap;
   padding: 15px 0;
 }
@@ -310,7 +309,7 @@ h3{
 }
 
 #featuresStages .list-unstyled > li {
-  margin-bottom: 25px;
+  margin-bottom: 35px;
   position: relative;
 }
 

--- a/about/styles/about.css
+++ b/about/styles/about.css
@@ -18,6 +18,11 @@ body {
   bottom: 7px;
 }
 
+.text-variant {
+  font-weight: 100;
+  font-size: 80%;
+}
+
 img {
   max-width: 100%;
 }
@@ -134,11 +139,11 @@ h3{
   font-size: 3.5em;
   font-weight: 900;
   position: absolute;
-  top: 33%;
+  top: 30%;
   left: 50%;
   transform: translate3d(-50%, -50%, 0);
   text-align: center;
-  max-width: 630px;
+  max-width: 588px;
 }
 
 #parallax a {
@@ -152,7 +157,7 @@ h3{
   border: 2px solid white;
   display: table;
   position: absolute;
-  top: 78%;
+  top: 80%;
   left: 50%;
   letter-spacing: 0.05em;
   transform: translate3d(-50%, -50%, 0);

--- a/src/less/stage-navbar.less
+++ b/src/less/stage-navbar.less
@@ -27,7 +27,7 @@
 			opacity: 0.6;
 			left: 120px;
 			bottom: 9px;
-			font-weight: bold;
+			font-weight: 900;
 			font-size: @font-size-smallest;
 			letter-spacing: 1px;
 			text-shadow: 0 3px 4px rgba(0,0,0,0.2);

--- a/src/nav-bar.js
+++ b/src/nav-bar.js
@@ -79,7 +79,7 @@ export class NavBar {
     });
 
     /*eslint-disable */
-    var pxScrolled = 100;
+    var pxScrolled = 25;
     var duration = 500;
 
     $(window).scroll(function() {


### PR DESCRIPTION
Minor JavaScript fix for when the navbar changes from transparent to black. Adjusted the `left` and `bottom`  values for the `alpha`/`beta` tags for the logo on the `Marketing`/`About` page.