### PR TITLE
home#178/home#179 Project Details updates.

### DIFF
--- a/src/components/headers/project-details-header.html
+++ b/src/components/headers/project-details-header.html
@@ -1,13 +1,17 @@
 <template>
   <div class="jumbotron hero-jumbotron secondary details">
     <div class="container-fluid">
-      <div class="proj-title">
+      <div class="proj-title clearfix">
         <div class="lang-logo">
           <img if.bind="repo.language != null" src="img/language-icons/${repo.language.toLowerCase()}.svg" onError="this.onerror=null;this.src='/img/language-icons/default.svg';">
           <img if.bind="repo.language == null" src="img/language-icons/default.svg">
         </div>
         <h1>${repo.project_name}</h1>
         <p>${repo.language ? repo.language : stageConfig.NO_LANG}</p>
+        <div class="btn-group">
+          <a class="btn btn-secondary btn-sm" href="#" onclick="history.go(-1)"><i class="material-icons">chevron_left</i>Back</a>
+          <a class="btn btn-secondary btn-sm" href="${repo.repositoryUrl}" target="_blank">View on Github<i class="material-icons">chevron_right</i></a>
+        </div>
       </div>
     </div>
   </div>

--- a/src/less/stage-jumbotron.less
+++ b/src/less/stage-jumbotron.less
@@ -177,6 +177,21 @@
 	      border: 1px solid @white;
 	      box-shadow: 0 5px 10px rgba(0,0,0,0.2);
 	    }
+
+	    .btn-group {
+	    	position: absolute;
+	    	top: 15px;
+	    	right: 20px;
+
+	    	.btn {
+	    		padding: 10px 15px;
+	    		text-shadow: none;
+	    	}
+
+	    	.btn-secondary {
+	    		border: none;
+	    	}
+	    }
     }
 
     .container-fluid {

--- a/src/less/stage-project-details.less
+++ b/src/less/stage-project-details.less
@@ -4,57 +4,9 @@
     padding: 0;
   }
 
-  .proj-nav {
-    .col-lg-12 {
-      margin-bottom: 0;
-
-      .list-inline {
-        margin: 8px 0;
-
-        > li {
-          padding-left: 10px;
-
-          .btn {
-            padding: 0;
-            font-size: @font-size-base;
-            color: lighten(@black, 25%);
-
-            .material-icons {
-              transition: all 0.1s linear;
-            }
-          }
-
-          &:first-child {
-            padding-left: 0;
-            padding-right: 15px;
-            border-right: 1px solid lighten(@black, 75%);
-
-            .btn {
-              &:hover {
-                .material-icons {
-                  transform: translateX(-4px);
-                }
-              }
-            }
-          }
-
-          &:last-child {
-            .btn {
-              &:hover {
-                .material-icons {
-                  transform: translateX(4px);
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
   .proj-content {
     .col-lg-12 {
-      margin-top: 0;
+      margin-top: 25px;
       margin-bottom: 0;
     }
   }

--- a/src/project-details/project-details.html
+++ b/src/project-details/project-details.html
@@ -7,14 +7,6 @@
   <div class="container-fluid cards-wrapper proj-details-wrapper">
     <div class="row flex-row">
       <div class="col-lg-9 col-md-9 col-content">
-        <div class="row proj-nav">
-          <div class="col-lg-12">
-            <ul class="list-inline">
-              <li><button onclick="window.history.go(-1); return false;" class="btn btn-link btn-sm"><i class="material-icons">chevron_left</i>Back</button></li>
-              <li><a class="btn btn-link btn-sm" href="${repo.repositoryUrl}" target="_blank">View on Github<i class="material-icons">chevron_right</i></a></li>
-            </ul>
-          </div>
-        </div>
         <div class="row proj-content">
           <div class="col-lg-12">
             <div class="card full-width">
@@ -69,57 +61,6 @@
                         <span class="stat-label">forks</span>
                       </span>
                     </div>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row proj-overview-row">
-                <div class="col-lg-4">
-                  <h3>Projects that we use</h3>
-                  <div class="row">
-                    <div class="col-lg-6">
-                      <ul class="list-unstyled">
-                        <li repeat.for="depend of repo.componentDependencies | pick:numDepends" if.bind = "$even"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
-                      </ul>
-                    </div>
-                    <div class="col-lg-6">
-                      <ul class="list-unstyled">
-                        <li repeat.for="depend of repo.componentDependencies | pick:numDepends" if.bind = "$odd"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
-                      </ul>
-                    </div>
-                    <div class="collapse" id="collapseDepend">
-                      <div class="col-lg-6">
-                        <ul class="list-unstyled">
-                          <li repeat.for="depend of repo.componentDependencies | skip:numDepends" if.bind = "$even"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
-                        </ul>
-                      </div>
-                      <div class="col-lg-6">
-                        <ul class="list-unstyled">
-                          <li repeat.for="depend of repo.componentDependencies | skip:numDepends" if.bind = "$odd"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
-                        </ul>
-                      </div>
-                    </div>
-                  </div>
-
-                  <button if.bind="repo.componentDependencies.length > numDepends" id="showMoreBtn" class="btn btn-link btn-sm" data-toggle="collapse" click.delegate="dependCollapsed = dependCollapsed !== true" href="#collapseDepend">
-                    <template if.bind="dependCollapsed">Show More <i class="material-icons">expand_more</i></template>
-                    <template if.bind="!dependCollapsed">Show Less <i class="material-icons">expand_less</i></template>
-                  </button>
-
-                </div>
-                <div class="col-lg-4">
-                  <h3>Projects that use us</h3>
-                  <div class="empty-state">
-                    <i class="material-icons">sentiment_dissatisfied</i>
-                    <em class="text-muted">Coming soon</em>
-                    <a href="#">Make Project Reusable</a>
-                  </div>
-                </div>
-                <div class="col-lg-4">
-                  <h3>Key technologies</h3>
-                  <div class="empty-state">
-                    <i class="material-icons">access_time</i>
-                    <em class="text-muted">Coming soon</em>
                   </div>
                 </div>
               </div>
@@ -197,6 +138,66 @@
                     </ul>
                   </div>
                   <a class="btn btn-link" href="#" target="_blank"><i class="material-icons">open_in_new</i> View on Fortify</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="row proj-content">
+          <div class="col-lg-12">
+            <div class="card full-width">
+              <div class="lined-header">
+                <h2 class=""><span>Dependencies</span></h2>
+              </div>
+              <div class="row proj-overview-row">
+                <div class="col-lg-4">
+                  <h3>Projects that we use</h3>
+                  <div class="row">
+                    <div class="col-lg-6">
+                      <ul class="list-unstyled">
+                        <li repeat.for="depend of repo.componentDependencies | pick:numDepends" if.bind = "$even"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
+                      </ul>
+                    </div>
+                    <div class="col-lg-6">
+                      <ul class="list-unstyled">
+                        <li repeat.for="depend of repo.componentDependencies | pick:numDepends" if.bind = "$odd"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
+                      </ul>
+                    </div>
+                    <div class="collapse" id="collapseDepend">
+                      <div class="col-lg-6">
+                        <ul class="list-unstyled">
+                          <li repeat.for="depend of repo.componentDependencies | skip:numDepends" if.bind = "$even"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
+                        </ul>
+                      </div>
+                      <div class="col-lg-6">
+                        <ul class="list-unstyled">
+                          <li repeat.for="depend of repo.componentDependencies | skip:numDepends" if.bind = "$odd"><strong>${depend.artifactId}</strong><small class="text-muted">${depend.version}</small></li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
+
+                  <button if.bind="repo.componentDependencies.length > numDepends" id="showMoreBtn" class="btn btn-link btn-sm" data-toggle="collapse" click.delegate="dependCollapsed = dependCollapsed !== true" href="#collapseDepend">
+                    <template if.bind="dependCollapsed">Show More <i class="material-icons">expand_more</i></template>
+                    <template if.bind="!dependCollapsed">Show Less <i class="material-icons">expand_less</i></template>
+                  </button>
+
+                </div>
+                <div class="col-lg-4">
+                  <h3>Projects that use us</h3>
+                  <div class="empty-state">
+                    <i class="material-icons">sentiment_dissatisfied</i>
+                    <em class="text-muted">Coming soon</em>
+                    <a href="#">Make Project Reusable</a>
+                  </div>
+                </div>
+                <div class="col-lg-4">
+                  <h3>Key technologies</h3>
+                  <div class="empty-state">
+                    <i class="material-icons">access_time</i>
+                    <em class="text-muted">Coming soon</em>
+                  </div>
                 </div>
               </div>
             </div>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -7345,6 +7345,18 @@ footer .bah-logo {
   border: 1px solid #ffffff;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
+.hero-banner .details .proj-title .btn-group {
+  position: absolute;
+  top: 15px;
+  right: 20px;
+}
+.hero-banner .details .proj-title .btn-group .btn {
+  padding: 10px 15px;
+  text-shadow: none;
+}
+.hero-banner .details .proj-title .btn-group .btn-secondary {
+  border: none;
+}
 .hero-banner .details .container-fluid {
   padding-top: 0;
 }
@@ -8140,36 +8152,8 @@ label.btn > input[type='radio'] {
 .proj-details-wrapper > .row {
   padding: 0;
 }
-.proj-details-wrapper .proj-nav .col-lg-12 {
-  margin-bottom: 0;
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline {
-  margin: 8px 0;
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline > li {
-  padding-left: 10px;
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline > li .btn {
-  padding: 0;
-  font-size: 14px;
-  color: #404040;
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline > li .btn .material-icons {
-  transition: all 0.1s linear;
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline > li:first-child {
-  padding-left: 0;
-  padding-right: 15px;
-  border-right: 1px solid #bfbfbf;
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline > li:first-child .btn:hover .material-icons {
-  transform: translateX(-4px);
-}
-.proj-details-wrapper .proj-nav .col-lg-12 .list-inline > li:last-child .btn:hover .material-icons {
-  transform: translateX(4px);
-}
 .proj-details-wrapper .proj-content .col-lg-12 {
-  margin-top: 0;
+  margin-top: 25px;
   margin-bottom: 0;
 }
 .proj-details-wrapper .col-content {


### PR DESCRIPTION
Moved the go back and view on Github buttons from the whitespace between the jumbotron and the first card to the right hand side of the jumbrotron. home #179 Moved the dependencies section to it's own card below the source code health section.